### PR TITLE
Add Stream Support for EPUB #64

### DIFF
--- a/ToxyFramework/Parsers/EPUB/EPUBHelper.cs
+++ b/ToxyFramework/Parsers/EPUB/EPUBHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using NPOI.SS.Util;
+using System.IO;
 using VersOne.Epub;
 
 namespace Toxy.Parsers
@@ -16,8 +17,14 @@ namespace Toxy.Parsers
 		public static EpubBook GetEpubBook(ParserContext context)
 		{
 			Utility.ValidateContext(context);
-			Stream stream = Utility.GetStream(context);
-			return EpubReader.ReadBook(stream);
+			if (!context.IsStreamContext)
+			{
+				using (FileStream fs = new FileStream(context.Path, FileMode.Open, FileAccess.Read))
+				{
+					return EpubReader.ReadBook(fs);
+				}
+			}
+			return EpubReader.ReadBook(context.Stream);
 		}
 	}
 }

--- a/ToxyFramework/Parsers/EPUB/EPUBHelper.cs
+++ b/ToxyFramework/Parsers/EPUB/EPUBHelper.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+using VersOne.Epub;
+
+namespace Toxy.Parsers
+{
+	/// <summary>
+	/// Contains utility Methods for EPUB Files.
+	/// </summary>
+	internal static class EPUBHelper
+	{
+		/// <summary>
+		/// Loads the <see cref="EpubBook"/> in <paramref name="context"/>
+		/// </summary>
+		/// <param name="context">Contains the Path to the EPUB File or the Stream.</param>
+		/// <returns>Returns the <see cref="EpubBook"/> in <paramref name="context"/>.</returns>
+		public static EpubBook GetEpubBook(ParserContext context)
+		{
+			Utility.ValidateContext(context);
+			Stream stream = Utility.GetStream(context);
+			return EpubReader.ReadBook(stream);
+		}
+	}
+}

--- a/ToxyFramework/Parsers/EPUB/EPUBMetaParser.cs
+++ b/ToxyFramework/Parsers/EPUB/EPUBMetaParser.cs
@@ -1,6 +1,4 @@
-﻿using HtmlAgilityPack;
-using System.Text;
-using VersOne.Epub;
+﻿using VersOne.Epub;
 
 namespace Toxy.Parsers
 {
@@ -13,10 +11,7 @@ namespace Toxy.Parsers
 		public virtual ParserContext Context { get; set; }
 		public ToxyMetadata Parse()
 		{
-			Utility.ValidateContext(Context);
-			StringBuilder result = new StringBuilder();
-			HtmlDocument html = new HtmlDocument();
-			EpubBook book = EpubReader.ReadBook(Context.Path);
+			EpubBook book = EPUBHelper.GetEpubBook(Context);
 			ToxyMetadata meta = new ToxyMetadata();
 			meta.Add(nameof(book.Author), book.Author);
 			meta.Add(nameof(book.AuthorList), book.AuthorList);

--- a/ToxyFramework/Parsers/EPUB/EPUBTextParser.cs
+++ b/ToxyFramework/Parsers/EPUB/EPUBTextParser.cs
@@ -5,13 +5,13 @@ using VersOne.Epub;
 
 namespace Toxy.Parsers
 {
-	public class EPUBTextParser : ITextParser
+	public sealed class EPUBTextParser : ITextParser
 	{
 		public EPUBTextParser(ParserContext context)
 		{
 			Context = context;
 		}
-		public virtual ParserContext Context { get; set; }
+		public ParserContext Context { get; set; }
 		public string Parse()
 		{
 			EpubBook book = EPUBHelper.GetEpubBook(Context);
@@ -21,7 +21,6 @@ namespace Toxy.Parsers
 			foreach (EpubLocalTextContentFile chapter in book.ReadingOrder)
 			{
 				html.LoadHtml(chapter.Content);
-				var a = whiteSpaceStart.Replace(html.DocumentNode.InnerText, "");
 				result.AppendLine(whiteSpaceStart.Replace(html.DocumentNode.InnerText, ""));
 			}
 			return result.ToString();

--- a/ToxyFramework/Parsers/EPUB/EPUBTextParser.cs
+++ b/ToxyFramework/Parsers/EPUB/EPUBTextParser.cs
@@ -14,10 +14,9 @@ namespace Toxy.Parsers
 		public virtual ParserContext Context { get; set; }
 		public string Parse()
 		{
-			Utility.ValidateContext(Context);
+			EpubBook book = EPUBHelper.GetEpubBook(Context);
 			StringBuilder result = new StringBuilder();
 			HtmlDocument html = new HtmlDocument();
-			EpubBook book = EpubReader.ReadBook(Context.Path);
 			Regex whiteSpaceStart = new Regex("^\\s*", RegexOptions.Multiline);
 			foreach (EpubLocalTextContentFile chapter in book.ReadingOrder)
 			{

--- a/ToxyFramework/ToxyFramework.csproj
+++ b/ToxyFramework/ToxyFramework.csproj
@@ -27,7 +27,8 @@
     <!-- Generate symbols package for debugging -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyName>Toxy</AssemblyName>    
+    <AssemblyName>Toxy</AssemblyName>
+    <RootNamespace>Toxy</RootNamespace>    
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added EPUBHelper, which gets the EPUB Book for the ParserContext. In addition the Context will also validated.
EPUBMetaParser & EPUBTextParser uses the new Method to get the EPUB Book

Changed the RootNamespace to Toxy since it will always use ToxyFramework for every new File