### PR TITLE
Remove .NET 6 target

### DIFF
--- a/ToxyFramework/ToxyFramework.csproj
+++ b/ToxyFramework/ToxyFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <AssemblyVersion>2.6</AssemblyVersion>
 


### PR DESCRIPTION
.NET 6 is end-of-support and .NET Standard 2.0 provides compatibility. Using NET8_0_OR_GREATER for any future optimizations.