### PR TITLE
Rewrite zip extraction

### DIFF
--- a/Toxy.sln
+++ b/Toxy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36511.14
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11619.145 insiders
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ToxyFramework", "ToxyFramework\ToxyFramework.csproj", "{97715000-D1AD-4AC5-A97E-CBCBCCFC8292}"
 EndProject

--- a/ToxyFramework/Helper/ThrowHelper.cs
+++ b/ToxyFramework/Helper/ThrowHelper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Toxy.Helper
+{
+	/// <summary>
+	/// Contains Methods, which throws an <see cref="Exception"/>.
+	/// </summary>
+	internal static class ThrowHelper
+	{
+#nullable enable
+		/// <summary>
+		/// Throws an <see cref="InvalidOperationException"/> indicating that the specified file is encrypted.
+		/// If the <paramref name="filePath"/> is not specified a more general exception will be thrown without additional Data.
+		/// </summary>
+		/// <param name="filePath">The full path or name of the file that is encrypted.</param>
+		/// <exception cref="InvalidOperationException">Always thrown to signal that encrypted files are not supported.</exception>
+#if NETCOREAPP2_1_OR_GREATER
+		[DoesNotReturn]
+		#endif
+		public static void ThrowEncrypted(string? filePath = null)
+		{
+			if (string.IsNullOrWhiteSpace(filePath))
+			{
+				throw new InvalidOperationException($"file {filePath} is encrypted");
+			}
+			throw new InvalidOperationException($"stream or file is encrypted");
+		}
+#nullable restore
+	}
+}

--- a/ToxyFramework/Helpers/ThrowHelper.cs
+++ b/ToxyFramework/Helpers/ThrowHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Toxy.Helper
+namespace Toxy.Helpers
 {
 	/// <summary>
 	/// Contains Methods, which throws an <see cref="Exception"/>.
@@ -20,7 +20,7 @@ namespace Toxy.Helper
 		#endif
 		public static void ThrowEncrypted(string? filePath = null)
 		{
-			if (string.IsNullOrWhiteSpace(filePath))
+			if (!string.IsNullOrWhiteSpace(filePath))
 			{
 				throw new InvalidOperationException($"file {filePath} is encrypted");
 			}

--- a/ToxyFramework/ParserFactory.cs
+++ b/ToxyFramework/ParserFactory.cs
@@ -109,9 +109,18 @@ namespace Toxy
             typeVcard.Add(typeof(VCardTextParser));
             parserMapping.Add(".vcf", typeVcard);
 
-            var typeZip = new List<Type>(1);
+            var typeZip = new List<Type>(10);
             typeZip.Add(typeof(ZipTextParser));
             parserMapping.Add(".zip", typeZip);
+            parserMapping.Add(".gz", typeZip);
+            parserMapping.Add(".tgz", typeZip);
+            parserMapping.Add(".tar", typeZip);
+            parserMapping.Add(".7z", typeZip);
+            parserMapping.Add(".rar", typeZip);
+            parserMapping.Add(".boz", typeZip);
+            parserMapping.Add(".bz2", typeZip);
+            parserMapping.Add(".lz", typeZip);
+            parserMapping.Add(".xz", typeZip);
 
             var typeAudio = new List<Type>(1);
             typeAudio.Add(typeof(AudioMetadataParser));

--- a/ToxyFramework/Parsers/ZipTextParser.cs
+++ b/ToxyFramework/Parsers/ZipTextParser.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Text;
 using Toxy.Base;
-using Toxy.Helper;
+using Toxy.Helpers;
 
 namespace Toxy.Parsers
 {

--- a/ToxyFramework/Parsers/ZipTextParser.cs
+++ b/ToxyFramework/Parsers/ZipTextParser.cs
@@ -1,44 +1,49 @@
-﻿using ICSharpCode.SharpZipLib.Zip;
-using PasswordProtectedChecker;
+﻿using SharpCompress.Archives;
+using SharpCompress.Readers;
+using System;
 using System.IO;
 using System.Text;
+using Toxy.Base;
+using Toxy.Helper;
 
 namespace Toxy.Parsers
 {
-    public class ZipTextParser : PlainTextParser
-    {
-        public ZipTextParser(ParserContext context)
-            : base(context)
-        {
-            this.Context = context;
-        }
-        public override string Parse()
-        {
-            Utility.ValidateContext(Context);
-            Utility.ThrowIfProtected(Context);
+	/// <summary>
+	/// The <see cref="ZipTextParser"/> is used to extract the Names of the Files & Directories inside compressed Files.
+	/// </summary>
+	public class ZipTextParser : BaseTextParser
+	{
+		/// <summary>
+		/// Initializes the <see cref="ZipTextParser"/>
+		/// </summary>
+		/// <param name="context">The <see cref="ParserContext"/> of the Parser.</param>
+		public ZipTextParser(ParserContext context) : base(context)
+		{ }
 
-            Stream stream = Utility.GetStream(Context);
-            try
-            {
-                StringBuilder sb = new StringBuilder();
-                using (ZipInputStream zipStream = new ZipInputStream(stream))
-                {
-                    ZipEntry entry = zipStream.GetNextEntry();
-                    while (entry != null)
-                    {
-                        sb.AppendLine(entry.Name);
-                        entry = zipStream.GetNextEntry();
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                if (!Context.IsStreamContext)
-                {
-                    stream.Dispose();
-                }
-            }
-        }
-    }
+		internal override string ParseText(out IDisposable disposable)
+		{
+			Stream stream = Utility.GetStream(Context);
+			// User Streams should not be closed!
+			ReaderOptions options = new ReaderOptions() { LeaveStreamOpen = Context.IsStreamContext };
+			IArchive archive = ArchiveFactory.OpenArchive(stream, options);
+			// set here to make sure it will get disposed even if we throw an exception
+			disposable = archive;
+			if (archive.IsEncrypted)
+			{
+				// can't read it
+				ThrowHelper.ThrowEncrypted(Context.Path);
+			}
+			StringBuilder result = new StringBuilder();
+			foreach (IArchiveEntry entry in archive.Entries)
+			{
+				if (entry.IsEncrypted)
+				{
+					// entries can be encrypted too
+					ThrowHelper.ThrowEncrypted(entry.Key);
+				}
+				result.AppendLine(entry.Key);
+			}
+			return result.ToString();
+		}
+	}
 }

--- a/ToxyFramework/Parsers/ZipTextParser.cs
+++ b/ToxyFramework/Parsers/ZipTextParser.cs
@@ -22,6 +22,13 @@ namespace Toxy.Parsers
 
 		internal override string ParseText(out IDisposable disposable)
 		{
+			/* * NOTE ABOUT ENCRYPTION:
+			 * In the ZIP file specification, encryption is applied at the entry level, not to the archive container itself.
+			 * A single ZIP archive can contain a mix of encrypted and unencrypted files.
+			 * Consequently, 'archive.IsEncrypted' may return false because the global directory doesn't always reflect the encryption status.
+			 * To reliably determine if a password is required, you must check the 'IsEncrypted' property of the individual entries.
+			*/
+
 			Stream stream = Utility.GetStream(Context);
 			// User Streams should not be closed!
 			ReaderOptions options = new ReaderOptions() { LeaveStreamOpen = Context.IsStreamContext };
@@ -30,7 +37,6 @@ namespace Toxy.Parsers
 			disposable = archive;
 			if (archive.IsEncrypted)
 			{
-				// can't read it
 				ThrowHelper.ThrowEncrypted(Context.Path);
 			}
 			StringBuilder result = new StringBuilder();
@@ -38,7 +44,6 @@ namespace Toxy.Parsers
 			{
 				if (entry.IsEncrypted)
 				{
-					// entries can be encrypted too
 					ThrowHelper.ThrowEncrypted(entry.Key);
 				}
 				result.AppendLine(entry.Key);

--- a/ToxyFramework/ToxyFramework.csproj
+++ b/ToxyFramework/ToxyFramework.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="PasswordProtectedChecker" Version="2.1.4" />
     <PackageReference Include="PdfPig" Version="0.1.14" />
     <PackageReference Include="ReasonableRTF.Standard" Version="2026.4.0" />
+    <PackageReference Include="SharpCompress" Version="0.47.3" />
     <PackageReference Include="Tabula" Version="0.1.5" />
     <PackageReference Include="taglib-sharp-netstandard2.0" Version="2.1.0" />
     <PackageReference Include="VCardReader" Version="1.2.3" />

--- a/ToxyFramework/Utility.cs
+++ b/ToxyFramework/Utility.cs
@@ -3,6 +3,7 @@ using FileSignatures;
 using PasswordProtectedChecker;
 using System;
 using System.IO;
+using Toxy.Helper;
 
 namespace Toxy
 {
@@ -70,7 +71,7 @@ namespace Toxy
 			if (result?.Protected ?? false)
 			{
                 // IDK what should be thrown in case of Streams.
-				throw new InvalidOperationException($"file {context.Path} is encrypted");
+                ThrowHelper.ThrowEncrypted(context.Path);
 			}
 		}
     }

--- a/ToxyFramework/Utility.cs
+++ b/ToxyFramework/Utility.cs
@@ -3,7 +3,7 @@ using FileSignatures;
 using PasswordProtectedChecker;
 using System;
 using System.IO;
-using Toxy.Helper;
+using Toxy.Helpers;
 
 namespace Toxy
 {


### PR DESCRIPTION
Whats changed?

Instead of ICSharpCode.SharpZipLib.Zip, SharpCompress is used for the extraction of compressed files.
Why?
SharpCompress seems to be active but SharpZipLib last commit is 3 years ago.
Also SharpCompress supports more Formats.

I added a new Helper "ThrowHelper", which contains general Methods to Throw
This has the reason that I check if the Zip is encrypted or contains encrypted entries.

I don't use PasswordProtectedChecker since it does not work on without copying the Stream temporarly in Memory. Because of that at the moment the result differ if a user pass a File as path or Stream. 